### PR TITLE
Fix milestone field in PullRequest struct

### DIFF
--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -33,7 +33,7 @@ pub fn handle_request(e: WebhookEvent) -> Result<()> {
 struct PullRequest {
     number: u64,
     merged: bool,
-    milestone: Option<u64>,
+    milestone: Option<Milestone>,
     base: Branch,
 }
 


### PR DESCRIPTION
- Fixed `milestone` field in `PullRequest` struct to handle pull  request event properly